### PR TITLE
Updated library to allow for slow device processing (RPi) and fix timeouts with hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Low-level client library for controlling Zigbee lights, switches by Lightify Wir
 ## Install
 
 ```bash
-$ npm install node-lightify-mg
+$ npm install node-lightify
 ```
 
 ## Usage
 
 ```javascript
-var lightify = require('node-lightify-mg');
+var lightify = require('node-lightify');
 var connection = new lightify.lightify('x.x.x.x');
 connection.connect().then(function(){
     return connection.discover();

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Low-level client library for controlling Zigbee lights, switches by Lightify Wir
 ## Install
 
 ```bash
-$ npm install node-lightify
+$ npm install node-lightify-mg
 ```
 
 ## Usage
 
 ```javascript
-var lightify = require('node-lightify');
+var lightify = require('node-lightify-mg');
 var connection = new lightify.lightify('x.x.x.x');
 connection.connect().then(function(){
     return connection.discover();

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ var lightify = function(ip, logger) {
         COMMAND_GET_STATUS
     ];
     this.connectErrorCount = 0;
+    this.sendNextRequest = this.sendNextRequestNormal;
 };
 lightify.prototype.processData = function(cmd, data) {
     var fail = data.readUInt8(8);
@@ -178,7 +179,7 @@ lightify.prototype.setDisconnectTimer = function () {
     if (!self.disconnectTimer || !self.buffers.length) _setTimer ();
 };
 
-lightify.sendNextRequest = lightify.prototype.sendNextRequestNormal = function (buffer) {
+lightify.prototype.sendNextRequestNormal = function (buffer) {
     if (buffer) this.client.write(buffer); // to overwrite it to use serialization
 };
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ const
     COMMAND_ONOFF = 0x32,
     COMMAND_TEMP = 0x33,
     COMMAND_COLOR = 0x36,
-
     COMMAND_SOFT_ON = 0xDB,
     COMMAND_SOFT_OFF = 0xDC,
     COMMAND_GET_ZONE_INFO = 0x26,
@@ -102,7 +101,7 @@ lightify.prototype.connect = function() {
             reject('connect timeout');
             self.logger && self.logger.debug('can not connect to lightify bridge, timeout');
             self.client.destroy();
-        }, 4000);
+        }, 20000);
         self.client.on('data', function(data) {
             self.logger && self.logger.debug('socket data: [%s]', data.toString('hex'))
             if(self.readBuffer && self.readBuffer.length) {
@@ -197,7 +196,7 @@ lightify.prototype.sendNextRequestAutoClose = function (buffer) {
                     self.logger && self.logger.debug('sendNextRequest: sent buffer done, remaining length=' + self.buffers.length);
                     if (self.buffers.length) {
                         if (nextTimer) clearTimeout(nextTimer);
-                        nextTimer = setTimeout (checkSend, 1000);
+                        nextTimer = setTimeout (checkSend, 5000);
                     }
                 }
                 break;
@@ -227,7 +226,7 @@ lightify.prototype.sendNextRequestAutoClose = function (buffer) {
 
 lightify.prototype.setAutoCloseConnection = function (on) {
     if (on) {
-        if (this.timeToStayConnected === undefined) this.timeToStayConnected = 3000;
+        if (this.timeToStayConnected === undefined) this.timeToStayConnected = 6000;
         this.buffers = this.buffers || [];
         this.buffers.length = 0;
         this.sendNextRequest = this.sendNextRequestAutoClose;
@@ -250,7 +249,7 @@ lightify.prototype.connectEx = function (cb, errorCb) {
             if (self.connectErrorCount++ < 5) setTimeout(function() {
                 self.client = undefined;
                 self.connectEx(cb);
-            }, 1000 * self.connectErrorCount);
+            }, 5000 * self.connectErrorCount);
             else {
                 errorCb && errorCb('Can not connect to Lightify Gateway ' + self.ip, error);
                 self.logger && self.logger.debug ('Can not connect to Lightify Gateway ' + self.ip);
@@ -306,7 +305,7 @@ lightify.prototype.sendCommand = function(cmdId, body, flag, cb, packageSize) {
             cmd.resolve = undefined;
             cmd.reject = undefined;
             self.sendNextRequest();
-        }, 1000);
+        }, 10000);
         self.logger && self.logger.debug('command sent [%s][%s]', cmd.seq, buffer.toString('hex'));
         self.commands.push(cmd);
         self.sendNextRequest(buffer);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-lightify",
-  "version": "2.1.10",
+  "name": "node-lightify-mg",
+  "version": "2.1.11",
   "description": "lightify node module",
   "license": "BSD",
   "keywords": [
@@ -10,10 +10,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/rainlake/node-lightify.git"
+    "url": "git://github.com/mylesgray/node-lightify.git"
   },
   "bugs": {
-    "url": "https://github.com/rainlake/node-lightify/issues"
+    "url": "https://github.com/mylesgray/node-lightify/issues"
   },
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lightify-mg",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "lightify node module",
   "license": "BSD",
   "keywords": [
@@ -10,10 +10,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/mylesgray/node-lightify.git"
+    "url": "git://github.com/mylesgray/node-lightify-mg.git"
   },
   "bugs": {
-    "url": "https://github.com/mylesgray/node-lightify/issues"
+    "url": "https://github.com/mylesgray/node-lightify-mg/issues"
   },
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-lightify-mg",
+  "name": "node-lightify",
   "version": "2.1.13",
   "description": "lightify node module",
   "license": "BSD",
@@ -10,10 +10,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/mylesgray/node-lightify-mg.git"
+    "url": "git://github.com/rainlake/node-lightify.git"
   },
   "bugs": {
-    "url": "https://github.com/mylesgray/node-lightify-mg/issues"
+    "url": "https://github.com/rainlake/node-lightify/issues"
   },
   "engines": {
     "node": ">=0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lightify-mg",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "lightify node module",
   "license": "BSD",
   "keywords": [


### PR DESCRIPTION
I have been running this for a number of weeks as part of https://github.com/rainlake/homebridge-platform-lightify/pull/15

No disconnects, failures or unresponsiveness to report, I am confident that these changes have fixed whatever underlying polling problem there was.

This PR needs to be accepted and published to NPM prior to the one referenced above as the package version has been changed.